### PR TITLE
Fixes and improvements

### DIFF
--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -38,9 +38,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -49,21 +49,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/1.8.3/amd64/debian/entrypoint.sh
+++ b/1.8.3/amd64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -38,9 +38,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -49,21 +49,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/1.8.3/arm64/debian/entrypoint.sh
+++ b/1.8.3/arm64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -38,9 +38,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -49,21 +49,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/1.8.3/armhf/debian/entrypoint.sh
+++ b/1.8.3/armhf/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/1.8.3/i386/alpine/entrypoint.sh
+++ b/1.8.3/i386/alpine/entrypoint.sh
@@ -38,9 +38,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -49,21 +49,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/1.8.3/i386/debian/entrypoint.sh
+++ b/1.8.3/i386/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.0.0/amd64/debian/entrypoint.sh
+++ b/2.0.0/amd64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.0.0/arm64/debian/entrypoint.sh
+++ b/2.0.0/arm64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.0.0/armhf/debian/entrypoint.sh
+++ b/2.0.0/armhf/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.0.0/i386/alpine/entrypoint.sh
+++ b/2.0.0/i386/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.0.0/i386/debian/entrypoint.sh
+++ b/2.0.0/i386/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.1.0/amd64/debian/entrypoint.sh
+++ b/2.1.0/amd64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.1.0/arm64/debian/entrypoint.sh
+++ b/2.1.0/arm64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.1.0/armhf/debian/entrypoint.sh
+++ b/2.1.0/armhf/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.1.0/i386/alpine/entrypoint.sh
+++ b/2.1.0/i386/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.1.0/i386/debian/entrypoint.sh
+++ b/2.1.0/i386/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.2.0/amd64/debian/entrypoint.sh
+++ b/2.2.0/amd64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.2.0/arm64/debian/entrypoint.sh
+++ b/2.2.0/arm64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.2.0/armhf/debian/entrypoint.sh
+++ b/2.2.0/armhf/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.2.0/i386/alpine/entrypoint.sh
+++ b/2.2.0/i386/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.2.0/i386/debian/entrypoint.sh
+++ b/2.2.0/i386/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.3.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.3.0-snapshot/amd64/debian/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.3.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.3.0-snapshot/arm64/debian/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.3.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.3.0-snapshot/armhf/debian/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/2.3.0-snapshot/i386/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/i386/alpine/entrypoint.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/2.3.0-snapshot/i386/debian/entrypoint.sh
+++ b/2.3.0-snapshot/i386/debian/entrypoint.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 

--- a/entrypoint_alpine.sh
+++ b/entrypoint_alpine.sh
@@ -46,9 +46,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< ${APPDIR}/userdata/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< ${APPDIR}/userdata.dist/etc/version.properties grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -57,21 +57,25 @@ case ${OPENHAB_VERSION} in
         if [ ! -d "${APPDIR}/userdata/backup" ]; then
           mkdir "${APPDIR}/userdata/backup"
         fi
-        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" -X "${APPDIR}/userdata/backup" "${APPDIR}/userdata"
+        tar -c -f "${APPDIR}/userdata/backup/${backupFile}" --exclude "backup/*" "${APPDIR}/userdata"
         echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
 
-	# Copy over the updated files
+        # Copy over the updated files
         cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"

--- a/entrypoint_debian.sh
+++ b/entrypoint_debian.sh
@@ -61,9 +61,9 @@ case ${OPENHAB_VERSION} in
       fi
 
       # Upgrade userdata if versions do not match
-      curVersion=$(< "${APPDIR}/userdata/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      imgVersion=$(< "${APPDIR}/userdata.dist/etc/version.properties" grep build-no | cut -d : -f 2 | tr -d '[:space]')
-      
+      curVersion=$(grep build-no "${APPDIR}/userdata/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+      imgVersion=$(grep build-no "${APPDIR}/userdata.dist/etc/version.properties" | cut -d : -f 2 | tr -d '[:space]')
+
       if [ "${curVersion}" != "${imgVersion}" ]; then
         echo "Image build number \"${imgVersion}\" is different from userdata build number \"${curVersion}\""
 
@@ -81,15 +81,19 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-	cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"	
+        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
+        fi
         cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
         cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-	cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
+        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 


### PR DESCRIPTION
* Skip copy of non-existing files
* Fix excluding backups directory on Alpine
* Simplify grep and add missing double quotes
* Correct indentation

Signed-off-by: Wouter Born <eclipse@maindrain.net>